### PR TITLE
Professions

### DIFF
--- a/app/javascript/history.coffee
+++ b/app/javascript/history.coffee
@@ -166,7 +166,7 @@ class ShadowcraftHistory
 
     decompress_handlers[version](data)
 
-  professionMap = [ "enchanting", "engineering", "blacksmithing", "inscription", "jewelcrafting", "leatherworking", "tailoring" ]
+  professionMap = [ "enchanting", "engineering", "blacksmithing", "inscription", "jewelcrafting", "leatherworking", "tailoring", "alchemy", "skinning", "herbalism" ]
   poisonMap = [ "ip", "dp", "wp" ]
   raceMap = ["Human", "Night Elf", "Worgen", "Dwarf", "Gnome", "Tauren", "Undead", "Orc", "Troll", "Blood Elf", "Goblin", "Draenei"]
   rotationOptionsMap = [

--- a/app/javascript/options.coffee
+++ b/app/javascript/options.coffee
@@ -122,7 +122,10 @@ class ShadowcraftOptions
       inscription: "Inscription",
       jewelcrafting: "Jewelcrafting",
       leatherworking: "Leatherworking",
-      tailoring: "Tailoring"
+      tailoring: "Tailoring",
+      alchemy: "Alchemy",
+      herbalism: "Herbalism",
+      skinning: "Skinning"
     })
 
     @setup("#settings #playerBuffs", "buffs", {


### PR DESCRIPTION
I'm guessing a bit here about how this stuff is working, but history.coffee has a  professionMap that's missing alchemy, skinning and herbalism. 

When a character is loaded with one of those professions from armory, they end up in Shadowcraft.Data.options.professions just fine. When the professions then go through the snapshotting mechanism in history.coffee, they are not found in the professionMap, and you end up with a property called "undefined" with value true on the professions object. The backend obviously doesn't do anything with that property, and the profession is "lost".

I also added the missing professions to the settings page (at least I think that's what I did ...). All of this is completely untested.
