### PR TITLE
Chaotic Metagems

### DIFF
--- a/app/javascript/backend.coffee
+++ b/app/javascript/backend.coffee
@@ -97,7 +97,7 @@ class ShadowcraftBackend
     gear_ids = []
     for k, g of data.gear
       gear_ids.push(g.item_id)
-      if k == 0 && g.g0 && Gems[g.g0] && Gems[g.g0].Meta
+      if k == "0" && g.g0 && Gems[g.g0] && Gems[g.g0].Meta
         if ShadowcraftGear.CHAOTIC_METAGEMS.indexOf(g.g0)
           payload.mg = "chaotic"
 


### PR DESCRIPTION
Swapping from Agile Shadowspirit Diamond to Fleet Shadowspirit Diamond only resulted in an 82 DPS loss and on further inspection I saw

```
Shadowcraft.Backend.buildPayload().mg
>>undefined
```

So the the metagem property still isn't being set.

Finally figured out the problem, CoffeeScript translates == to === and since data.gear is an object, the `k` in the for loop is a String and the condition k === 0 is always false.
