### PR TITLE
fixed make.watchr, was outputting to -o.js

### DIFF
--- a/app/javascript/make.watchr
+++ b/app/javascript/make.watchr
@@ -24,7 +24,7 @@ watch( "(#{scripts.join("|")})\.coffee" ) do |md|
   end
 
   path = File.join(File.dirname(__FILE__), "..", "..", "public", "javascripts")
-  cmd = "coffee -c -j -o #{path} #{scripts.map {|s| "#{s}.coffee"}.join " "}"
+  cmd = "coffee -c -j concatenation.js -o #{path} #{scripts.map {|s| "#{s}.coffee"}.join " "}"
   puts "Compiling package: #{cmd}"
   `#{cmd}`
 end


### PR DESCRIPTION
make.watchr script was missing a file argument to -j and
was writing it's output to -o.js instead of concatenation.js

I was using watchr 0.7 and coffeescript 1.1.1 when I ran into this issue.
