### PR TITLE
Backend update

### DIFF
--- a/app/assets/javascripts/core/gear.coffee
+++ b/app/assets/javascripts/core/gear.coffee
@@ -151,7 +151,7 @@ class ShadowcraftGear
 
     if (ilvl_diff == 0)
       ilvl_diff = gear.item_level-item.ilvl
-    
+
     sumItem(output, item_stats, ilvl_diff)
 
   # Sums all of the stats passed in into a second map of stats, recalculating for
@@ -203,10 +203,6 @@ class ShadowcraftGear
 
     for si, i in SLOT_ORDER
       Shadowcraft.Gear.sumSlot(data.gear[si], stats, null)
-
-    # Add the base character agility and multiply by the bonus we get for wearing
-    # all leather gear. Finally, round to an even number.
-    stats['agility'] = Math.round((stats['agility'] + 9030) * 1.05)
 
     @statSum = stats
     return stats
@@ -732,7 +728,6 @@ class ShadowcraftGear
         buffer += Templates.itemSlot(opt)
 
       $slots.get(ssi).innerHTML = buffer
-    this.updateStatsWindow()
     this.updateSummaryWindow()
     checkForWarnings('gear')
 
@@ -789,18 +784,19 @@ class ShadowcraftGear
     $summary.get(0).innerHTML = Templates.stats {stats: a_stats}
 
   # Updates the display of the Gear Stats section of the Gear tab.
-  updateStatsWindow: ->
-    this.sumStats()
+  updateStatsWindow = (source) ->
     $stats = $("#stats .inner")
     a_stats = []
-    keys = _.keys(@statSum).sort()
+    keys = _.keys(source.stats).sort()
     total = 0
     for idx, stat of keys
-      weight = getStatWeight(stat, @statSum[stat], null, true)
+      if source.stats[stat] == 0
+        continue
+      weight = getStatWeight(stat, source.stats[stat], null, true)
       total += weight
       a_stats.push {
         name: titleize(stat),
-        val: @statSum[stat],
+        val: Math.round(source.stats[stat]),
         # ep: Math.floor(weight)
       }
 
@@ -1514,9 +1510,9 @@ class ShadowcraftGear
     Shadowcraft.Backend.bind("recompute", -> Shadowcraft.Gear )
     Shadowcraft.Backend.bind("recompute", updateDpsBreakdown)
     Shadowcraft.Backend.bind("recompute", updateEngineInfoWindow)
+    Shadowcraft.Backend.bind("recompute", updateStatsWindow)
 
     Shadowcraft.Talents.bind "changed", ->
-      app.updateStatsWindow()
       app.updateSummaryWindow()
 
     Shadowcraft.bind "loadData", ->

--- a/backend/app/shadowcraft/__init__.py
+++ b/backend/app/shadowcraft/__init__.py
@@ -520,6 +520,14 @@ class ShadowcraftComputation:
             out["breakdown"] = calculator.get_dps_breakdown()
             out["total_dps"] = sum(entry[1] for entry in out["breakdown"].items())
 
+            # Get character stats used for calculation (should equal armory)
+            out["stats"] = calculator.stats.get_character_stats(calculator.race)
+            # Filter interesting stats
+            out["stats"]["agility"] = out["stats"]["agi"]
+            for key in out["stats"].keys():
+                if key not in ['agility', 'crit', 'versatility', 'mastery', 'haste']:
+                    del out["stats"][key]
+
             # Get EP Values
             default_ep_stats = ['agi', 'haste', 'crit', 'mastery', 'versatility', 'ap']
             _opt = input.get("settings", {})

--- a/backend/app/shadowcraft/__init__.py
+++ b/backend/app/shadowcraft/__init__.py
@@ -342,7 +342,7 @@ class ShadowcraftComputation:
 
         # ##################################################################################
         # Set up gear buffs.
-        buff_list = []
+        buff_list = ['gear_specialization']
 
         if len(self.tier18IDs & gear) >= 2:
             buff_list.append('rogue_t18_2pc')
@@ -359,6 +359,9 @@ class ShadowcraftComputation:
         if len(self.tier19IDs & gear) >= 4:
             buff_list.append('rogue_t19_4pc')
 
+        if len(self.orderhallIDs & gear) >= 6:
+            buff_list.append('rogue_orderhall_6pc')
+
         if len(self.orderhallIDs & gear) == 8:
             buff_list.append('rogue_orderhall_8pc')
 
@@ -373,12 +376,6 @@ class ShadowcraftComputation:
 
         if len(self.toeKneesIDs & gear) == 2 or len(self.bloodstainedIDs & gear) == 2 or len(self.eyeOfCommandIDs & gear) == 2:
             buff_list.append('kara_empowered_2pc')
-
-        agi_bonus = 0
-        if len(self.tier18LFRIDs & gear) >= 2:
-            agi_bonus += 115
-        if len(self.orderhallIDs & gear) >= 6:
-            agi_bonus += 500
 
         for k,v in self.gearBoosts.iteritems():
             if k in gear:
@@ -425,7 +422,7 @@ class ShadowcraftComputation:
         _stats = stats.Stats(
             mh=_mh, oh=_oh, procs=_procs, gear_buffs=_gear_buffs,
             str=s[0],             # Str
-            agi=s[1] + agi_bonus, # AGI
+            agi=s[1],             # AGI
             int=0,
             stam=0,
             ap=s[2],              # AP

--- a/backend/app/shadowcraft/__init__.py
+++ b/backend/app/shadowcraft/__init__.py
@@ -54,6 +54,11 @@ class ShadowcraftComputation:
         137537: 'tirathons_betrayal',
         137486: 'windscar_whetstone',
         144259: 'kiljaedens_burning_wish',
+
+        # Return to Karazhan
+        142159: 'bloodstained_handkerchief',
+        142167: 'eye_of_command',
+        142164: 'toe_knees_promise',
     }
 
     otherProcs = {
@@ -177,6 +182,11 @@ class ShadowcraftComputation:
         'natures_call': xrange(850, 955, 5),
         'bloodthirsty_instinct': xrange(850, 955, 5),
 
+        # Return to Karazhan
+        'bloodstained_handkerchief': xrange(855, 955, 5),
+        'eye_of_command': xrange(860, 955, 5),
+        'toe_knees_promise': xrange(855, 955, 5),
+
         # Nighthold trinkets
         'arcanogolem_digit': xrange(860, 955, 5),
         'convergence_of_fates': xrange(860, 955, 5),
@@ -185,7 +195,7 @@ class ShadowcraftComputation:
         'draught_of_souls': xrange(860, 955, 5),
 
         # Legendary trinkets
-        'kiljaedens_burning_wish': [910],
+        'kiljaedens_burning_wish': [910, 940],
     }
 
     gearBoosts = {


### PR DESCRIPTION
This includes a few additions for new gear buffs and procs in the engine. Also, since we were handling some stat bonuses not at all or twice, let's just pass the sum of gear stats to the engine and display stats returned from the engine that should match Armory values (if the player did not have flask/food etc. active on logout).

Depends on Fierydemise/ShadowCraft-Engine#32 to be merged.