### PR TITLE
Fix lethal poison switch

### DIFF
--- a/app/assets/javascripts/core/gear.coffee
+++ b/app/assets/javascripts/core/gear.coffee
@@ -773,11 +773,11 @@ class ShadowcraftGear
             when "shuriken_storm" then "Shuriken Storm"
       }
     else if ShadowcraftTalents.GetActiveSpecName() == "Assassination"
-      if data.options.general.lethal_poison
+      if data.options.rotation.lethal_poison
         a_stats.push {
           name: "Poison"
           val:
-            switch data.options.general.lethal_poison
+            switch data.options.rotation.lethal_poison
               when "wp" then "Wound"
               when "dp" then "Deadly"
         }
@@ -1721,7 +1721,7 @@ class ShadowcraftGear
     # Bind to the update event from the Options tab for changes that affect the
     # Gear tab.
     Shadowcraft.Options.bind "update", (opt, val) ->
-      if opt in ['rotation.cp_builder','rotation.blade_flurry','general.num_boss_adds','general.lethal_poison']
+      if opt in ['rotation.cp_builder','rotation.blade_flurry','general.num_boss_adds','rotation.lethal_poison']
         app.updateSummaryWindow()
 
     this.updateDisplay()

--- a/app/assets/javascripts/core/gear.coffee
+++ b/app/assets/javascripts/core/gear.coffee
@@ -879,7 +879,7 @@ class ShadowcraftGear
     max = _.max(rankings)
     $("#dpsbreakdown .talent_contribution").hide()
     for skill, val of dps_breakdown
-      skill = skill.replace('(','').replace(')','').split(' ').join('_')
+      skill = skill.replace('(','').replace(')','').replace(/'/g, '').split(' ').join('_')
       val = parseFloat(val)
       name = titleize(skill)
       skill = skill.replace(/\./g,'_')

--- a/app/assets/javascripts/core/options.coffee
+++ b/app/assets/javascripts/core/options.coffee
@@ -213,13 +213,6 @@ class ShadowcraftOptions
         # Show the mutilate section (otherwise known as the assassination section)
         $("#settings section.mutilate").show()
 
-        # If the user has the agonizing poison talent selected, add that to the
-        # menu for poisons.
-        if (Shadowcraft.Data.activeTalents.split("")[5] == "0")
-          $("#opt-rotation-lethal_poison").append($("<option></option>").attr("value","ap").text("Agonizing Poison"))
-        else
-          $("#opt-rotation-lethal_poison option[value='ap']").remove()
-
       # "Z" is for outlaw
       else if Shadowcraft.Data.activeSpec == "Z"
         $("#settings section.combat").show()
@@ -232,22 +225,6 @@ class ShadowcraftOptions
 
       # Deeper strategem modifies a lot of options, so just check for it for all specs
       ds_active = (Shadowcraft.Data.activeTalents.split("")[2] == "0")
-
-      Shadowcraft.Console.remove(".options-poisons")
-      if Shadowcraft.Data.activeSpec == "a"
-        # if in assassination, check to see if agonizing poison is selected
-        agonizing = (Shadowcraft.Data.activeTalents.split("")[5] == "0")
-        poisonSelect = $("#opt-rotation-lethal_poison")
-
-        # if the user has ap selected in the options, but don't have the talent
-        # selected, default back to dp and warn the user that we did it.
-        if !agonizing
-          if poisonSelect.val() == "ap"
-            Shadowcraft.Console.warn("ap", "Agonizing Poison was selected in options. Defaulting to Deadly Poison", null, "warn", "options-poisons")
-            poisonSelect.val("dp")
-          $("#opt-rotation-lethal_poison option[value='ap']").remove()
-        else
-          poisonSelect.append($("<option></option>").attr("value","ap").text("Agonizing Poison"))
 
       finisher_threshold = $("#opt-general-finisher_threshold")
       if ds_active

--- a/backend/app/shadowcraft/__init__.py
+++ b/backend/app/shadowcraft/__init__.py
@@ -93,7 +93,7 @@ class ShadowcraftComputation:
             238102: 'dense_concoction',
             238138: 'sinister_circulation',
             239042: 'concordance_of_the_legionfall',
-            
+
         },
 
         # Outlaw/Dreadblades traits
@@ -291,6 +291,7 @@ class ShadowcraftComputation:
           'kingsbane_with_vendetta',
           'exsang_with_vendetta',
           'cp_builder',
+          'lethal_poison'
       ], [
           'blade_flurry',
           'between_the_eyes_policy',

--- a/backend/app/shadowcraft/__init__.py
+++ b/backend/app/shadowcraft/__init__.py
@@ -233,6 +233,8 @@ class ShadowcraftComputation:
         133976: 'cinidaria_the_symbiote',
         144236: 'mantle_of_the_master_assassin',
         132452: 'sephuzs_secret',
+        134542: 'jeweled_signet_of_melandrus',
+        134526: 'gnawed_thumb_ring',
     }
 
     # combines gearProcs and gearBoosts


### PR DESCRIPTION
Counterpart is now implemented in engine. However, I removed the addition of Agonizing Poison to the
menu because we decided to have it use AP anyway when talented into it.